### PR TITLE
34 install vercel analytics

### DIFF
--- a/components/views/contact/ContactForm.vue
+++ b/components/views/contact/ContactForm.vue
@@ -45,6 +45,8 @@ const sendMessage = async () => {
       method: "POST",
       body: {
         email: formData.email,
+        name: formData.name,
+        lastName: formData.lastName,
         message: formData.message,
       },
     });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,6 +19,15 @@ export default defineNuxtConfig({
     "@nuxtjs/i18n",
   ],
   ssr: false,
+  app: {
+    head: {
+      script: [
+        ...(process.env.NODE_ENV === "production"
+          ? [{ src: "/_vercel/insights/script.js", defer: true }]
+          : []),
+      ],
+    },
+  },
   css: [
     "@/assets/styles/fonts.css",
     "@/assets/styles/vueTransitions.css",

--- a/server/api/send.ts
+++ b/server/api/send.ts
@@ -15,6 +15,8 @@ export default defineEventHandler(async (event) => {
       subject: "Nuevo mensaje de tu portfolio",
       html: `
       <p><strong>Email:</strong> ${body.email}</p>
+      <p><strong>Nombre:</strong> ${body.name}</p>
+      <p><strong>Apellidos:</strong> ${body.lastName}</p>
       <p><strong>Mensaje:</strong></p>
       <p>${body.message}</p>
     `,


### PR DESCRIPTION
- #34 

**Adds Vercel Analytics tracking for production builds.**

The official `@vercel/analytics` npm package was discarded due to a peer dependency conflict — it pulls in `@sveltejs/kit`, which requires Vite 8, while the project runs on Vite 6. Instead, the script is injected directly via `app.head` in `nuxt.config.ts`, which is the recommended approach for non-React frameworks and requires no additional dependencies.
The script is conditionally included only when `NODE_ENV === "production"`, so local development stays clean with no 404 errors in the console. Vercel automatically serves the script at `/_vercel/insights/script.js` on deployment.

### Changes

- Added `/_vercel/insights/script.js` to app.head.script in nuxt.config.ts
- Gated the script behind a production env check

### Verification

- No errors in local dev
- Analytics dashboard active in Vercel after deployment